### PR TITLE
ros bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,25 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   rospy
   std_msgs
+  roscpp
+  sensor_msgs
+  nav_msgs
+  geometry_msgs
+  tf
+  tf2_ros
 )
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+
+# OPTIONAL BUILD OF CPP BRIDGE
+set(BUILD_CPP_BRIDGE ON)
+
+if(${BUILD_CPP_BRIDGE})
+  find_package(lcm REQUIRED)
+  set(ACFR_LCM_CPP_TYPES /usr/local/include/perls-lcmtypes++)
+endif()
+
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -117,6 +135,8 @@ catkin_package(
 include_directories(
 # include
   ${catkin_INCLUDE_DIRS}
+  ${LCM_INCLUDE_DIR}
+  ${ACFR_LCM_CPP_TYPES}
 )
 
 ## Declare a C++ library
@@ -127,12 +147,12 @@ include_directories(
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/rowbot_lcm_ros_bridge_node.cpp)
+
+
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -145,10 +165,14 @@ include_directories(
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
 
+if(${BUILD_CPP_BRIDGE})
+  add_executable(nav_bridge src/nav_bridge.cpp)
+  target_link_libraries(nav_bridge
+    ${catkin_LIBRARIES}
+    ${LCM_LIBRARY}
+  )
+endif()
 #############
 ## Install ##
 #############

--- a/cmake/Findlcm.cmake
+++ b/cmake/Findlcm.cmake
@@ -1,0 +1,32 @@
+INCLUDE(FindPackageHandleStandardArgs)
+
+SET(LCM_IncludeSearchPaths
+  /usr/include/
+  /usr/local/include/
+  /opt/local/include
+)
+
+SET(LCM_LibrarySearchPaths
+  /usr/lib/
+  /usr/local/lib/
+  /opt/local/lib/
+)
+
+FIND_PATH(LCM_INCLUDE_DIR lcm/lcm.h
+  PATHS ${LCM_IncludeSearchPaths}
+)
+FIND_LIBRARY(LCM_LIBRARY
+  NAMES lcm
+  PATHS ${LCM_LibrarySearchPaths}
+)
+
+# Handle the REQUIRED argument and set the <UPPERCASED_NAME>_FOUND variable
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LCM "Could NOT find LCM library (LCM)"
+  LCM_LIBRARY
+  LCM_INCLUDE_DIR
+)
+
+MARK_AS_ADVANCED(
+  LCM_LIBRARY
+  LCM_INCLUDE_DIR
+)

--- a/launch/nav.launch
+++ b/launch/nav.launch
@@ -1,0 +1,3 @@
+<launch>
+    <node pkg = "rowbot_lcm_ros_bridge" type="nav_bridge.py" name="nav_bridge"/>
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -50,9 +50,27 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>nav_msgs</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>tf</build_export_depend>
+  <build_export_depend>tf2_ros</build_export_depend>
   <exec_depend>rospy</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/scripts/gps_bridge_enu_basic.py
+++ b/scripts/gps_bridge_enu_basic.py
@@ -45,7 +45,7 @@ def my_handler(channel, data):
     if use_imu == True:
         rospy.logdebug("Publishing imu")
         imumsg = Imu()
-        q = quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading+np.pi/2)) # TODO check this
+        q = quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading-np.pi/2)) # TODO check this
         imumsg.orientation.x = q[0]
         imumsg.orientation.y = q[1]
         imumsg.orientation.z = q[2]
@@ -58,7 +58,7 @@ def my_handler(channel, data):
         imu_pub.publish(imumsg)
     if use_odom == True:
         br = tf.TransformBroadcaster()
-        q = quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading+np.pi/2)) # TODO check this
+        q = quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading-np.pi/2)) # TODO check this
 
         rospy.logdebug("Publishing odom")
         odommsg = Odometry()
@@ -85,7 +85,7 @@ def my_handler(channel, data):
 
         odom_pub.publish(odommsg)
         br.sendTransform((msg.y, msg.x, 0),
-                     tf.transformations.quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading+np.pi/2)),
+                     tf.transformations.quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading-np.pi/2)),
                      rospy.Time.now(),
                      "base_link",
                      "odom")

--- a/scripts/gps_bridge_enu_basic.py
+++ b/scripts/gps_bridge_enu_basic.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python2
+import sys
+sys.path.insert(0, '/usr/local/lib/python2.7/dist-packages/perls/lcmtypes')
+import lcm
+import math
+import tf
+from acfrlcm import auv_acfr_nav_t
+import rospy
+from tf.transformations import quaternion_from_euler
+from sensor_msgs.msg import NavSatFix
+from sensor_msgs.msg import NavSatStatus
+from nav_msgs.msg import Odometry
+from std_msgs.msg import Header
+from sensor_msgs.msg import Imu
+import numpy as np
+seq = 0
+
+def my_handler(channel, data):
+    global seq
+    fix_pub = rospy.Publisher('fix', NavSatFix, queue_size=10)
+    odom_pub = rospy.Publisher('odom',Odometry,queue_size=10)
+    imu_pub = rospy.Publisher('imu/data',Imu,queue_size=10)
+    use_odom=True
+    use_fix = True
+    use_imu = True
+
+    gps_frame = "novatel"
+    headermsg = Header()
+    headermsg.seq = seq +1
+    headermsg.stamp = rospy.Time.now()
+    headermsg.frame_id = gps_frame
+
+    msg = auv_acfr_nav_t.decode(data)
+    if use_fix== True:
+        rospy.logdebug("Publising gps info")
+        fixmsg = NavSatFix()
+        fixmsg.header = headermsg
+        fixmsg.latitude = math.radians(msg.latitude)
+        fixmsg.longitude = math.radians(msg.longitude)
+        fixmsg.altitude = msg.altitude
+        fixmsg.position_covariance = [0,0,0,0,0,0,0,0,0]
+        fixmsg.position_covariance_type = 0
+        fix_pub.publish(fixmsg)
+
+    if use_imu == True:
+        rospy.logdebug("Publishing imu")
+        imumsg = Imu()
+        q = quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading+np.pi/2)) # TODO check this
+        imumsg.orientation.x = q[0]
+        imumsg.orientation.y = q[1]
+        imumsg.orientation.z = q[2]
+        imumsg.orientation.w = q[3]
+
+        imumsg.angular_velocity.x = msg.pitchRate
+        imumsg.angular_velocity.y = msg.rollRate
+        imumsg.angular_velocity.z = -msg.headingRate
+
+        imu_pub.publish(imumsg)
+    if use_odom == True:
+        br = tf.TransformBroadcaster()
+        q = quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading+np.pi/2)) # TODO check this
+
+        rospy.logdebug("Publishing odom")
+        odommsg = Odometry()
+        odommsg.header = headermsg
+        odommsg.header.frame_id = "odom"
+
+        #TODO, USE TRANSFORM
+        odommsg.child_frame_id ="base_link"
+        odommsg.pose.pose.position.x = msg.y
+        odommsg.pose.pose.position.y = msg.x
+        odommsg.pose.pose.position.z = -msg.altitude
+        odommsg.pose.pose.orientation.x = q[0]
+        odommsg.pose.pose.orientation.y = q[1]
+        odommsg.pose.pose.orientation.z = q[2]
+        odommsg.pose.pose.orientation.w = q[3]
+
+
+        odommsg.twist.twist.linear.x = msg.vy
+        odommsg.twist.twist.linear.y = msg.vx
+        odommsg.twist.twist.linear.z = -msg.vz
+        odommsg.twist.twist.angular.x = msg.pitchRate
+        odommsg.twist.twist.angular.y = msg.rollRate
+        odommsg.twist.twist.angular.z = -msg.headingRate
+
+        odom_pub.publish(odommsg)
+        br.sendTransform((msg.y, msg.x, 0),
+                     tf.transformations.quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading+np.pi/2)),
+                     rospy.Time.now(),
+                     "base_link",
+                     "odom")
+
+
+
+lc = lcm.LCM()
+rospy.init_node('lcmtoRosFix', anonymous=True)
+
+#TODO GET CHANNEL FROM PARAM
+subscription = lc.subscribe("WAMV.ACFR_NAV", my_handler)
+
+try:
+    while True:
+        lc.handle()
+except KeyboardInterrupt:
+    pass
+
+lc.unsubscribe(subscription)

--- a/scripts/motor_driver.py
+++ b/scripts/motor_driver.py
@@ -9,7 +9,8 @@ from std_msgs.msg import Float32
 lc = lcm.LCM()
 
 def callback_left(message):
-    port_channel  = "WAMV.PORT_MOTOR_CONTROL"
+    # port_channel  = "WAMV.PORT_MOTOR_CONTROL"
+    port_channel = "WAMV.LEFT_ROS_CMD"
     port = message.data
     port_msg = asv_torqeedo_motor_command_t()
     utime = long(rospy.get_time())*1000000
@@ -22,7 +23,8 @@ def callback_left(message):
 
 def callback_right(message):
     utime = long(rospy.get_time())*1000000
-    starboard_channel  = "WAMV.STBD_MOTOR_CONTROL"
+    # starboard_channel = "WAMV.STBD_MOTOR_CONTROL"  # This controls the motors directly
+    starboard_channel = "WAMV.RIGHT_ROS_CMD"
     starboard = message.data
     starboard_msg = asv_torqeedo_motor_command_t()
     starboard_msg.command_speed = starboard*650

--- a/scripts/nav_bridge.py
+++ b/scripts/nav_bridge.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python2
+import sys
+sys.path.insert(0, '/usr/local/lib/python2.7/dist-packages/perls/lcmtypes')
+import lcm
+import math
+import tf
+from acfrlcm import auv_acfr_nav_t
+import rospy
+from tf.transformations import quaternion_from_euler
+from sensor_msgs.msg import NavSatFix
+from sensor_msgs.msg import NavSatStatus
+from nav_msgs.msg import Odometry
+from std_msgs.msg import Header
+from sensor_msgs.msg import Imu
+import numpy as np
+
+class NavBridge:
+    def __init__(self):
+        self.lc = lcm.LCM()
+        self.lc_sub = self.lc.subscribe("WAMV.ACFR_NAV", self.handler)
+
+        self.fix_pub_ = rospy.Publisher('fix', NavSatFix, queue_size=10)
+        self.odom_pub_ = rospy.Publisher('odom',Odometry,queue_size=10)
+        self.imu_pub_ = rospy.Publisher('imu/data',Imu,queue_size=10)
+        self.use_odom_ = True
+        self.use_fix_ = True
+        self.use_imu_ = True
+
+        self.gps_frame_ = "novatel"
+
+        self.seq_ = 0
+
+    def unsub(self):
+        self.lc.unsubscribe(self.lc_sub)
+
+    def handler(self, channel, data):
+        """The LCM callback. Receives the LCM messages, publishes ROS messages.
+
+        Args:
+            channel (str): The channel it is received on.
+            data (type): Description of parameter `data`.
+
+        Returns:
+            type: Description of returned object.
+
+        """
+        # Header Message
+        headermsg = Header()
+        headermsg.seq = self.seq +1
+        headermsg.stamp = rospy.Time.now()
+        headermsg.frame_id = self.gps_frame_
+
+        # GPS
+        msg = auv_acfr_nav_t.decode(data)
+        if self.use_fix_ == True:
+            rospy.logdebug("Publising gps info")
+            fixmsg = NavSatFix()
+            fixmsg.header = headermsg
+            fixmsg.latitude = math.radians(msg.latitude)
+            fixmsg.longitude = math.radians(msg.longitude)
+            fixmsg.altitude = msg.altitude
+            fixmsg.position_covariance = [0,0,0,0,0,0,0,0,0]
+            fixmsg.position_covariance_type = 0
+            self.fix_pub_.publish(fixmsg)
+
+        if self.use_imu_ == True:
+            rospy.logdebug("Publishing imu")
+            imumsg = Imu()
+            q = quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading-np.pi/2)) # TODO check this
+            imumsg.orientation.x = q[0]
+            imumsg.orientation.y = q[1]
+            imumsg.orientation.z = q[2]
+            imumsg.orientation.w = q[3]
+
+            imumsg.angular_velocity.x = msg.pitchRate
+            imumsg.angular_velocity.y = msg.rollRate
+            imumsg.angular_velocity.z = -msg.headingRate
+
+            self.imu_pub_.publish(imumsg)
+
+        if self.use_odom_ == True:
+            br = tf.TransformBroadcaster()
+            q = quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading-np.pi/2)) # TODO check this
+
+            rospy.logdebug("Publishing odom")
+            odommsg = Odometry()
+            odommsg.header = headermsg
+            odommsg.header.frame_id = "odom"
+
+            #TODO, USE TRANSFORM
+            odommsg.child_frame_id ="base_link"
+            odommsg.pose.pose.position.x = msg.y
+            odommsg.pose.pose.position.y = msg.x
+            odommsg.pose.pose.position.z = -msg.altitude
+            odommsg.pose.pose.orientation.x = q[0]
+            odommsg.pose.pose.orientation.y = q[1]
+            odommsg.pose.pose.orientation.z = q[2]
+            odommsg.pose.pose.orientation.w = q[3]
+
+
+            odommsg.twist.twist.linear.x = msg.vy
+            odommsg.twist.twist.linear.y = msg.vx
+            odommsg.twist.twist.linear.z = -msg.vz
+            odommsg.twist.twist.angular.x = msg.pitchRate
+            odommsg.twist.twist.angular.y = msg.rollRate
+            odommsg.twist.twist.angular.z = -msg.headingRate
+
+            self.odom_pub_.publish(odommsg)
+            br.sendTransform((msg.y, msg.x, 0),
+                         tf.transformations.quaternion_from_euler(msg.pitch, msg.roll, -np.unwrap(msg.heading-np.pi/2)),
+                         rospy.Time.now(),
+                         "base_link",
+                         "odom")
+
+if __name__ == "__main__":
+    rospy.init_node('lcmtoRosFix', anonymous=True)
+
+    navbr = NavBridge()
+
+    try:
+        while True:
+            navbr.lc.handle()
+    except KeyboardInterrupt:
+        pass
+
+    navbr.unsub()

--- a/src/nav_bridge.cpp
+++ b/src/nav_bridge.cpp
@@ -1,0 +1,138 @@
+#include <stdio.h>
+#include <ros/ros.h>
+#include <lcm/lcm-cpp.hpp>
+#include <math.h>
+#include "perls-lcmtypes++/acfrlcm/auv_acfr_nav_t.hpp"
+#include <nav_msgs/Odometry.h>
+#include <sensor_msgs/NavSatFix.h>
+#include <sensor_msgs/Imu.h>
+#include <std_msgs/Header.h>
+#include <tf/transform_datatypes.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <geometry_msgs/TransformStamped.h>
+
+
+class NavBridge
+{
+    public:
+        NavBridge()
+        {
+            odomPub_ = n_.advertise<nav_msgs::Odometry>("/odom", 1);
+            fixPub_ = n_.advertise<sensor_msgs::NavSatFix>("/fix", 1);
+            imuPub_ = n_.advertise<sensor_msgs::Imu>("/imu", 1);
+        }
+        ~NavBridge() {}
+
+        void handleMessage(const lcm::ReceiveBuffer* rbuf,
+                const std::string& chan,
+                const acfrlcm::auv_acfr_nav_t *nav)
+        {
+            if(ros::ok)
+            {
+                std_msgs::Header header_msg;
+                header_msg.stamp =  ros::Time::now();
+                header_msg.seq = seq_;
+                seq_++; // Increment the sequence
+
+                tf2::Quaternion quat;
+                quat.setRPY(nav->pitch, nav->roll, -NavBridge::unwrap(nav->heading - M_PI_2)); //TODO convert to ENU
+                quat.normalize();
+
+                // Fill the Odometry message
+                nav_msgs::Odometry odom_msg;
+                odom_msg.header = header_msg;
+                odom_msg.header.frame_id = "odom";
+                odom_msg.child_frame_id ="base_link";
+                odom_msg.pose.pose.position.x = nav->y;
+                odom_msg.pose.pose.position.y = nav->x;
+                odom_msg.pose.pose.position.z = -nav->depth;
+                odom_msg.pose.pose.orientation.x = quat[0];
+                odom_msg.pose.pose.orientation.y = quat[1];
+                odom_msg.pose.pose.orientation.z = quat[2];
+                odom_msg.pose.pose.orientation.w = quat[3];
+
+                odom_msg.twist.twist.linear.x = nav->vy;
+                odom_msg.twist.twist.linear.y = nav->vx;
+                odom_msg.twist.twist.linear.z = -nav->vz;
+                odom_msg.twist.twist.angular.x = nav->pitchRate;
+                odom_msg.twist.twist.angular.y = nav->rollRate;
+                odom_msg.twist.twist.angular.z = -nav->headingRate;
+
+                // Publish the odom message
+                odomPub_.publish(odom_msg);
+
+                // IMU
+                sensor_msgs::Imu imu_msg;
+                imu_msg.orientation.x = quat[0];
+                imu_msg.orientation.y = quat[1];
+                imu_msg.orientation.z = quat[2];
+                imu_msg.orientation.w = quat[3];
+
+                imu_msg.angular_velocity.x = nav->pitchRate;
+                imu_msg.angular_velocity.y = nav->rollRate;
+                imu_msg.angular_velocity.z = -nav->headingRate;
+
+                imuPub_.publish(imu_msg);
+
+                // Fix Publish
+                sensor_msgs::NavSatFix fix_msg;
+                fix_msg.header = header_msg;
+                fix_msg.header.frame_id = "novatel";
+                fix_msg.latitude = nav->latitude;
+                fix_msg.longitude = nav->longitude;
+                fix_msg.altitude = nav->altitude;
+                fixPub_.publish(fix_msg);
+
+                // Send the transform
+                static tf2_ros::TransformBroadcaster br;
+                geometry_msgs::TransformStamped trStamp;
+                trStamp.header = header_msg;
+                trStamp.header.frame_id = "odom";
+                trStamp.child_frame_id = "base_link";
+                trStamp.transform.translation.x = odom_msg.pose.pose.position.x;
+                trStamp.transform.translation.y = odom_msg.pose.pose.position.y;
+                trStamp.transform.translation.z = odom_msg.pose.pose.position.z;
+                trStamp.transform.translation.z = odom_msg.pose.pose.position.z;
+                trStamp.transform.rotation.x = quat.x();
+                trStamp.transform.rotation.y = quat.y();
+                trStamp.transform.rotation.z = quat.z();
+                trStamp.transform.rotation.w = quat.w();
+
+                br.sendTransform(trStamp);
+            }
+
+        }
+        // Keeps the angle between -pi, pi
+        double unwrap(double x)
+        {
+            x = fmod(x + M_PI,2*M_PI);
+            if (x < 0)
+                x += 2*M_PI;
+            return x - M_PI;
+        }
+    private:
+        ros::NodeHandle n_;
+        ros::Publisher odomPub_;
+        ros::Publisher imuPub_;
+        ros::Publisher fixPub_;
+        int seq_;
+
+};
+
+int main(int argc, char** argv)
+{
+    lcm::LCM lcm;
+
+    ros::init(argc, argv, "nav_bridge");
+
+    if(!lcm.good())
+        return 1;
+
+    NavBridge nb;
+    lcm.subscribe("WAMV.ACFR_NAV", &NavBridge::handleMessage, &nb);
+
+    while(0 == lcm.handle());
+
+    return 0;
+}


### PR DESCRIPTION
A couple of updates over the previous ros bridge. These were used for field tests on 29/10,30/10,7/11.
 
Summary of changes:
- swapped coordinates from NED to ENU
- publish to RIGHT_ROS_CMD instead of directly to LCM motor command channel. Allows for switching of modes and safety to be implemented.
- Added a cpp node, that isn't tested